### PR TITLE
Revert "Update dependency ffigen to v7.2.7"

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -22,7 +22,7 @@ dependencies:
 
 dev_dependencies:
   build_runner: ^2.1.11
-  ffigen: 7.2.7
+  ffigen: 7.1.0
   lints: ^2.0.0
   macro_builder:
     path: tool/macro_builder


### PR DESCRIPTION
Reverts ubuntu-flutter-community/stdlibc.dart#70, see https://github.com/ubuntu-flutter-community/stdlibc.dart/pull/73 for more details.

```
  error - lib/src/bsd/ffigen.dart:1857:12 - Fields in struct classes can't have the type 'UnnamedUnion1'. They can only be declared as 'int', 'double', 'Array', 'Pointer', or subtype of 'Struct' or 'Union'. Try using 'int', 'double', 'Array', 'Pointer', or subtype of 'Struct' or 'Union'. - invalid_field_type_in_struct
```